### PR TITLE
Add support for filtering releases by date range in a single API call…

### DIFF
--- a/src/FredDKAspNetSample/Program.cs
+++ b/src/FredDKAspNetSample/Program.cs
@@ -30,9 +30,9 @@ namespace FredDKAspNetSample
             app.UseAuthorization();
 
             // add a sample endpoint to get releases
-            app.MapGet("/api/releases", async (IFredReleaseService releaseService) =>
+            app.MapGet("/api/releases", async (IFredReleaseService releaseService, DateOnly? startDate, DateOnly? endDate) =>
             {
-                return (await releaseService.GetReleases()).ToMinimalApiResult();
+                return (await releaseService.GetReleases(startDate, endDate)).ToMinimalApiResult();
             });
 
             app.Run();

--- a/src/FredDKSample/Examples/ReleasesExample.cs
+++ b/src/FredDKSample/Examples/ReleasesExample.cs
@@ -22,7 +22,21 @@ namespace FredDKSample.Examples
             ShowTagsResult(await releaseService.GetTags(19));
             ShowTagsResult(await releaseService.GetRelatedTags(19, new List<string> { "services", "quarterly" }));
         }
-        public static void ShowReleasesResults(Result<ReleaseResponseDto> releasesResult)
+        public static void ShowReleasesResults(Result<ReleasesResponseDto> releasesResult)
+        {
+            if (releasesResult.IsSuccess)
+            {
+                foreach (Release release in releasesResult.Value.Releases)
+                {
+                    Console.WriteLine($"Release name is {release.Name} id is {release.Id}");
+                }
+            }
+            else
+            {
+                Console.WriteLine("Releases not found");
+            }
+        }
+        public static void ShowReleaseDatesResults(Result<ReleaseResponseDto> releasesResult)
         {
             if (releasesResult.IsSuccess)
             {

--- a/src/FredDevelopmentKit/Services/IFredReleaseService.cs
+++ b/src/FredDevelopmentKit/Services/IFredReleaseService.cs
@@ -5,8 +5,8 @@ namespace FredDevelopmentKit.Services
 {
     public interface IFredReleaseService
     {
-        Task<Result<ReleaseResponseDto>> GetReleases();
-        Task<Result<ReleasesDatesResponseDto>> GetReleasesDates(); 
+        Task<Result<ReleasesResponseDto>> GetReleases(DateOnly? startDate = null, DateOnly? endDate = null);
+        Task<Result<ReleasesDatesResponseDto>> GetReleasesDates(DateOnly? startDate = null, DateOnly? endDate = null); 
         Task<Result<Release>> GetRelease(int releaseId);
         Task<Result<ReleaseDateResponseDto>> GetReleaseDates(int releaseId);
         Task<Result<RelatedSeriesResponseDto>> GetSeries(int releaseId);


### PR DESCRIPTION
….  The FRED API

does not allow this, so the release service will act as BFF / aggregator and call the release dates service to get the releases in the given date range, then filter the list of releases based on the results of that call.